### PR TITLE
chore(build): ignore commitlint on automation commit

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,5 +1,0 @@
-{
-  "extends": [
-    "@commitlint/config-conventional"
-  ]
-}

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,10 @@
+const automaticCommitPattern = /^chore\(release\):.*\[skip ci]/;
+
+module.exports = {
+  extends: [
+    '@commitlint/config-conventional',
+  ],
+  ignores: [
+    commitMsg => automaticCommitPattern.test(commitMsg),
+  ],
+};


### PR DESCRIPTION
It's fail when semantic-release generate commit message, line-length is too long.
So it should be ignore for now.